### PR TITLE
hotfix: Correct address resolver and rule set names in singbox config

### DIFF
--- a/core/scripts/normalsub/singbox.json
+++ b/core/scripts/normalsub/singbox.json
@@ -24,12 +24,11 @@
       {
         "type": "https",
         "server": "1.1.1.1",
-        "address_resolver": "local-dns",
         "detour": "proxy",
         "tag": "proxy-dns"
       },
       {
-        "address": "local",
+        "type": "local",
         "detour": "direct",
         "tag": "local-dns"
       }
@@ -146,13 +145,13 @@
         "rule_set": [
           "geosite-ir",
           "geoip-ir",
-          "geosite-private"
+          "geoip-private"
         ]
       },
       {
         "action": "reject",
         "rule_set": [
-          "geoip-ads"
+          "geosite-ads"
         ]
       }
     ]


### PR DESCRIPTION
- Aligned rulesets with corresponding tags for consistency and accuracy.
- Updated the local DNS configuration to comply with the latest changes introduced in Sing-box version 1.12.0.
- Removed "address resolver" as it's redundant when using the direct IP (1.1.1.1).

* Tested on Sing-box v1.12.0-beta.19 (Android).